### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 This project implements a Model Context Protocol (MCP) server that acts as a bridge to interact with the Coda API. It allows an MCP client (like an AI assistant) to perform actions on a specific Coda document, such as listing, creating, reading, updating, and duplicating pages.
 
+<a href="https://glama.ai/mcp/servers/@orellazri/coda-mcp">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/@orellazri/coda-mcp/badge" alt="Coda Server MCP server" />
+</a>
+
 ## Features
 
 The server exposes the following tools to the MCP client:


### PR DESCRIPTION
This PR adds a badge for the [Coda MCP Server](https://glama.ai/mcp/servers/@orellazri/coda-mcp) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/@orellazri/coda-mcp">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/@orellazri/coda-mcp/badge" alt="Coda Server MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly assess that the MCP server is safe, server capabilities, and instructions for installing the server.