### PR TITLE
feat: add valueFormat parameter to list_rows and get_row

### DIFF
--- a/src/server.test.ts
+++ b/src/server.test.ts
@@ -981,6 +981,7 @@ describe("coda_list_rows", () => {
         query: undefined,
         sortBy: undefined,
         useColumnNames: true,
+        valueFormat: "rich",
         limit: undefined,
         pageToken: undefined,
       },
@@ -1004,6 +1005,7 @@ describe("coda_list_rows", () => {
         query: '"Name":"Alice"',
         sortBy: "updatedAt",
         useColumnNames: true,
+        valueFormat: "rich",
         limit: undefined,
         pageToken: undefined,
       },
@@ -1027,6 +1029,7 @@ describe("coda_list_rows", () => {
         query: undefined,
         sortBy: undefined,
         useColumnNames: true,
+        valueFormat: "rich",
         limit: undefined,
         pageToken: "token-abc",
       },
@@ -1063,7 +1066,7 @@ describe("coda_get_row", () => {
     ]);
     expect(sdk.getRow).toHaveBeenCalledWith({
       path: { docId: "doc-123", tableIdOrName: "grid-123", rowIdOrName: "i-row1" },
-      query: { useColumnNames: true },
+      query: { useColumnNames: true, valueFormat: "rich" },
       throwOnError: true,
     });
   });
@@ -1082,7 +1085,7 @@ describe("coda_get_row", () => {
     });
     expect(sdk.getRow).toHaveBeenCalledWith({
       path: { docId: "doc-123", tableIdOrName: "grid-123", rowIdOrName: "i-row1" },
-      query: { useColumnNames: false },
+      query: { useColumnNames: false, valueFormat: "rich" },
       throwOnError: true,
     });
   });

--- a/src/server.ts
+++ b/src/server.ts
@@ -377,6 +377,13 @@ server.tool(
       .optional()
       .default(true)
       .describe("Use column names instead of column IDs in the output - defaults to true"),
+    valueFormat: z
+      .enum(["simple", "simpleWithArrays", "rich"])
+      .optional()
+      .default("rich")
+      .describe(
+        "The format that cell values are returned as. 'rich' returns detailed objects for images, people, and references. 'simple' returns plain strings. Defaults to 'rich'.",
+      ),
     limit: z.number().int().positive().optional().describe("The number of rows to return - optional"),
     nextPageToken: z
       .string()
@@ -385,7 +392,7 @@ server.tool(
         "The token needed to get the next page of results, returned from a previous call to this tool - optional",
       ),
   },
-  async ({ docId, tableIdOrName, query, sortBy, useColumnNames, limit, nextPageToken }): Promise<CallToolResult> => {
+  async ({ docId, tableIdOrName, query, sortBy, useColumnNames, valueFormat, limit, nextPageToken }): Promise<CallToolResult> => {
     try {
       const listLimit = nextPageToken ? undefined : limit;
 
@@ -395,6 +402,7 @@ server.tool(
           query: query ?? undefined,
           sortBy: sortBy ?? undefined,
           useColumnNames,
+          valueFormat,
           limit: listLimit,
           pageToken: nextPageToken ?? undefined,
         },
@@ -420,12 +428,19 @@ server.tool(
       .optional()
       .default(true)
       .describe("Use column names instead of column IDs in the output - defaults to true"),
+    valueFormat: z
+      .enum(["simple", "simpleWithArrays", "rich"])
+      .optional()
+      .default("rich")
+      .describe(
+        "The format that cell values are returned as. 'rich' returns detailed objects for images, people, and references. 'simple' returns plain strings. Defaults to 'rich'.",
+      ),
   },
-  async ({ docId, tableIdOrName, rowIdOrName, useColumnNames }): Promise<CallToolResult> => {
+  async ({ docId, tableIdOrName, rowIdOrName, useColumnNames, valueFormat }): Promise<CallToolResult> => {
     try {
       const resp = await getRow({
         path: { docId, tableIdOrName, rowIdOrName },
-        query: { useColumnNames },
+        query: { useColumnNames, valueFormat },
         throwOnError: true,
       });
 


### PR DESCRIPTION
## Summary
- Add `valueFormat` parameter (`simple`, `simpleWithArrays`, `rich`) to `list_rows` and `get_row` tools
- Default to `rich` format so cell values return detailed objects for images, people, and references instead of plain strings
- Update tests to reflect the new parameter

## Test plan
- [x] Updated existing tests to include `valueFormat` parameter
- [x] All tests pass with the new default value
- [x] Tested this one myself

🤖 Generated with [Claude Code](https://claude.com/claude-code)